### PR TITLE
Implement data-math attribute checks for katex.Works on gemini

### DIFF
--- a/content.js
+++ b/content.js
@@ -262,6 +262,18 @@ document.addEventListener('mouseover', (e) => {
     }
   }
 
+  // Check for math elements with data-math
+  const dataMathEl = e.target.closest('[data-math]');
+  if (dataMathEl) {
+    const tex = dataMathEl.getAttribute('data-math');
+    if (tex && tex.trim()) {
+      currentTarget = dataMathEl;
+      dataMathEl.classList.add('hoverlatex-hover');
+      showOverlay(dataMathEl, tex.trim());
+      return;
+    }
+  }
+
   // Check for MathJax v3 elements
   const mjxContainer = e.target.closest('mjx-container');
   if (mjxContainer) {
@@ -292,6 +304,7 @@ document.addEventListener('mouseover', (e) => {
 document.addEventListener('mouseout', (e) => {
   if (currentTarget && 
       !e.relatedTarget?.closest('.katex') && 
+      !e.relatedTarget?.closest('[data-math]') &&
       !e.relatedTarget?.closest('mjx-container') &&
       !e.relatedTarget?.closest('.MathJax_Display, .MJXc-display') && 
       !e.relatedTarget?.closest('.MathJax, .mjx-chtml, .MathJax_CHTML, .MathJax_MathML') &&
@@ -322,6 +335,16 @@ document.addEventListener('click', (e) => {
     const tex = findAnnotationTex(katex);
     if (tex) {
       copyLatex(tex);
+      return;
+    }
+  }
+
+  // Check for math elements with data-math
+  const dataMathEl = e.target.closest('[data-math]');
+  if (dataMathEl) {
+    const tex = dataMathEl.getAttribute('data-math');
+    if (tex && tex.trim()) {
+      copyLatex(tex.trim());
       return;
     }
   }

--- a/content.js
+++ b/content.js
@@ -189,7 +189,7 @@ function createOverlay() {
   overlay = document.createElement('div');
   overlay.className = 'hoverlatex-overlay';
 
-  // Contingut HTML amb SVG i text
+  // HTML overlay content with inline SVG icon and 'Click to copy' text
   overlay.innerHTML = `
     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" 
          viewBox="0 0 24 24" fill="none" stroke="currentColor" 
@@ -228,7 +228,7 @@ function hideOverlay() {
 function copyLatex(tex) {
   navigator.clipboard.writeText(tex).then(() => {
     overlay.classList.add('copied');
-    overlay.querySelector('span').textContent = 'Copied! ✅';
+    overlay.querySelector('span').textContent = 'Copied! ✅'; // todo: replace emoji with inline svg tw icon: https://mapaor.github.io/tw-emojis/tw-emojis-svgs/2705.svg
     setTimeout(() => {
       overlay.classList.remove('copied');
       overlay.querySelector('span').textContent = 'Click to copy';
@@ -339,12 +339,12 @@ document.addEventListener('click', (e) => {
     }
   }
 
-  // Check for math elements with data-math
+  // Check for elements (div or span) with custom attribute `data-math` (for Gemini)
   const dataMathEl = e.target.closest('[data-math]');
   if (dataMathEl) {
     const tex = dataMathEl.getAttribute('data-math');
-    if (tex && tex.trim()) {
-      copyLatex(tex.trim());
+    if (tex) {
+      copyLatex(tex);
       return;
     }
   }


### PR DESCRIPTION
Added checks for math elements with data-math attribute to show overlay and copy LaTeX.Works on gemini.google.com.

Now wen can correctly parse format like:
`<span class="math-inline" data-math="a \ge 0" data-index-in-node="14">...</span>`
<img width="749" height="119" alt="图片" src="https://github.com/user-attachments/assets/0002ad44-ed95-4afc-927d-441dfec1d112" />

Works well on gemini.

block math screenshot:
<img width="626" height="299" alt="图片" src="https://github.com/user-attachments/assets/f28fa652-0bd1-4e91-b124-c6398644a298" />

inline math screenshot:
<img width="626" height="299" alt="图片" src="https://github.com/user-attachments/assets/9bf95b89-286a-4853-b2c1-c97613a87386" />
